### PR TITLE
Add trim to the brand name

### DIFF
--- a/src/controllers/phoneController.js
+++ b/src/controllers/phoneController.js
@@ -81,7 +81,7 @@ exports.specs = async (req, res) => {
             return errorJson(res, `Phone not found`, 404);
         }
         return json(res, {
-            brand: data.brand,
+            brand: data.brand.trim(),
             phone_name: data.phone_name,
             phone_name_slug: data.phone_name_slug,
             phone_img_url: data.phone_img_url,


### PR DESCRIPTION
In order to prevent empty space on the brand name string, I added a .trim()

If you access [Here](https://api-mobilespecs.azharimm.site/v2/brands/acer-phones-59), you would see that there is a space in every string in brand field, like this:


` 
{
        "brand": "Acer ",
        "phone_name": "Chromebook Tab 10",
        "slug": "acer_chromebook_tab_10-9139",
        "image": "https://fdn2.gsmarena.com/vv/bigpic/acer-chromebook-tab-10.jpg",
        "detail": "http://api-mobilespecs.azharimm.site/v2/acer_chromebook_tab_10-9139"
},
`
