### PR TITLE
fix(README): replace http with https

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The data is based on gsmarena site
 [ENDPOINT] /v2/search
 ```
 ```
-[GET] http://api-mobilespecs.azharimm.site/v2/search?query= iPhone 12 pro max
+[GET] https://api-mobilespecs.azharimm.site/v2/search?query= iPhone 12 pro max
 ```
 ### Query params
 | params        | desc | required |


### PR DESCRIPTION
This PR fixed an issue in the README.md file where the link was only `http` instead of `https`.